### PR TITLE
Make rating required if acf field is required

### DIFF
--- a/StarRatingField.php
+++ b/StarRatingField.php
@@ -259,6 +259,10 @@ class StarRatingField extends acf_field
             $valid = __('The value is too large!', 'acf-star_rating_field');
         }
         
+        if ( $field['required'] == 1 && $value == 0 ) {
+            $valid = sprintf( __('Please enter a value clicking on stars form 1 to %s', 'acf-star_rating_field'), $field['max_stars']);
+        }
+        
         return $valid;
     }
     


### PR DESCRIPTION
if acf field is required user must cast a rating to submit the form.
Not sure about the text string for the error, but the check is working.