### PR TITLE
Change package type to "wordpress-plugin"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kevinruscoe/acf-star-rating-field",
     "description": "A simple star rating field for ACF.",
-    "type": "acf-plugin",
+    "type": "wordpress-plugin",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
The package type "acf-plugin" is not recognized by the [`composer/installers`](https://github.com/composer/installers). 
This has to be installed as a WordPress plugin to be usable.