### PR TITLE
Fix storing of data when used in an ACF block

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -44,6 +44,8 @@
 					}
 				}
 			});
+
+			starField.trigger("change");
 		});
 
 		clearButton.bind("click", function(e){
@@ -52,6 +54,8 @@
 			clearActiveStarClassesFromList();
 
 			starField.val(0);
+
+			starField.trigger("change");
 		});
 
 		function clearActiveStarClassesFromList()


### PR DESCRIPTION
The field data did not update properly when used inside of an ACF block.
The WP Block Editor seems to rely on the `change` event getting triggered on fields in order for data to get updated in the block.

The `change` event was never triggered on the starfield since it's a hidden field updated with the help of JS.

This PR should fixes the above issues by triggering a `change` event.